### PR TITLE
chore: improve env example, fix Docker Python version

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,41 @@
-# ...existing code...
-# Add to .env.example for user configuration
-SLACK_WEBHOOK_URL=
-GENERIC_WEBHOOK_URL=
-# ...existing code...
+# OneAlert Configuration
+# Copy to .env and fill in your values
+
+# ── Core ──────────────────────────────────────────────
+SECRET_KEY=change-me-to-a-random-64-char-string
+ENVIRONMENT=development          # development | staging | production
+
+# ── Database ──────────────────────────────────────────
+# SQLite (default, no setup needed):
+DATABASE_URL=sqlite:///./cybersec_alerts.db
+# PostgreSQL (production):
+# DATABASE_URL=postgresql://user:password@localhost:5432/onealert
+
+# ── AI Provider ───────────────────────────────────────
+AI_PROVIDER=anthropic             # anthropic | openai | ollama | vllm | groq
+ANTHROPIC_API_KEY=               # sk-ant-...
+# AI_API_KEY=                    # For OpenAI-compatible providers
+# AI_BASE_URL=http://localhost:11434/v1  # For Ollama/vLLM
+# AI_TRIAGE_MODEL=claude-sonnet-4-20250514
+# AI_DEFAULT_MODEL=claude-sonnet-4-20250514
+
+# ── GitHub OAuth (optional) ───────────────────────────
+# GITHUB_CLIENT_ID=
+# GITHUB_CLIENT_SECRET=
+# GITHUB_REDIRECT_URI=http://localhost:8000/api/v1/auth/github/callback
+
+# ── Stripe Billing (optional) ────────────────────────
+# STRIPE_SECRET_KEY=
+# STRIPE_PUBLISHABLE_KEY=
+
+# ── Email Alerts via Mailgun (optional) ───────────────
+# MAILGUN_API_KEY=
+# MAILGUN_DOMAIN=
+# FROM_EMAIL=alerts@yourdomain.com
+
+# ── Notification Webhooks (optional) ──────────────────
+# SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...
+# GENERIC_WEBHOOK_URL=https://your-siem.example.com/webhook
+
+# ── NVD API (optional, higher rate limits) ────────────
+# NVD_API_KEY=

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY frontend-v2/ .
 RUN npm run build
 
 # Stage 2: Python runtime
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 WORKDIR /app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   app:
     build: .
@@ -13,6 +11,10 @@ services:
       - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY:-}
       - MAILGUN_API_KEY=${MAILGUN_API_KEY:-}
       - MAILGUN_DOMAIN=${MAILGUN_DOMAIN:-}
+      - AI_PROVIDER=${AI_PROVIDER:-anthropic}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - AI_API_KEY=${AI_API_KEY:-}
+      - AI_BASE_URL=${AI_BASE_URL:-}
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- Replace stub `.env.example` with comprehensive documented template covering all config options
- Bump Dockerfile Python 3.11 → 3.12 (matches CI)
- Remove deprecated `version` key from docker-compose.yml
- Add AI provider env vars to docker-compose (AI agents need API keys to work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)